### PR TITLE
chore: remove registry

### DIFF
--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -13,7 +13,6 @@ spec:
     gitServer: https://github.com
     kanikoFlags: --skip-unused-stages --snapshotMode=redo
     provider: gke
-    registry: gcr.io
   environments:
   - key: dev
   - key: staging


### PR DESCRIPTION
From version 1.12.0 of https://github.com/jenkins-x/terraform-google-jx registry is by default set by the terraform module, so it would be overwritten anyway.

Part of fix for jenkins-x/jx#8656